### PR TITLE
Add leading slash to type

### DIFF
--- a/componentDetection.ts
+++ b/componentDetection.ts
@@ -120,21 +120,22 @@ export default class ComponentDetection {
   }
 
   public static makePackageUrl(packageUrlJson: any): string {
-    var packageUrl = `${packageUrlJson.Scheme}:${packageUrlJson.Type}/`;
+    var typeWithSlash = packageUrlJson.Type.startsWith('/') ? packageUrlJson.Type : '/' + packageUrlJson.Type;
+    var packageUrl = `${packageUrlJson.Scheme}:${typeWithSlash}/`;
     if (packageUrlJson.Namespace) {
-      packageUrl += `${packageUrlJson.Namespace.replaceAll("@", "%40")}/`;
+        packageUrl += `${packageUrlJson.Namespace.replaceAll("@", "%40")}/`;
     }
     packageUrl += `${packageUrlJson.Name.replaceAll("@", "%40")}`;
     if (packageUrlJson.Version) {
-      packageUrl += `@${packageUrlJson.Version}`;
+        packageUrl += `@${packageUrlJson.Version}`;
     }
     if (typeof packageUrlJson.Qualifiers === "object"
-      && packageUrlJson.Qualifiers !== null
-      && Object.keys(packageUrlJson.Qualifiers).length > 0) {
-      const qualifierString = Object.entries(packageUrlJson.Qualifiers)
-        .map(([key, value]) => `${key}=${value}`)
-        .join("&");
-      packageUrl += `?${qualifierString}`;
+        && packageUrlJson.Qualifiers !== null
+        && Object.keys(packageUrlJson.Qualifiers).length > 0) {
+        const qualifierString = Object.entries(packageUrlJson.Qualifiers)
+            .map(([key, value]) => `${key}=${value}`)
+            .join("&");
+        packageUrl += `?${qualifierString}`;
     }
     return packageUrl;
   }


### PR DESCRIPTION
```
        "/node_modules/vm2/package.json": {
            "name": "/node_modules/vm2/package.json",
            "file": {
                "source_location": "/node_modules/vm2/package.json"
            },
            "resolved": {
                "pkg:npm/vm2@3.9.17": {
                    "package_url": "pkg:npm/vm2@3.9.17",
                    "relationship": "direct",
                    "scope": "runtime"
                }
            }
        },
```
`pkg:npm/vm2@3.9.17` is not detecting alerts:

![image](https://github.com/user-attachments/assets/f5070b2f-b9db-4b7f-92bc-604c5217571f)
