### PR TITLE
Fix dependabot config and CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,14 @@ updates:
     schedule:
       interval: weekly
     groups: 
-      patterns:
-        - "*"
+      actions-dependencies
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups: 
+      npm-dependencies
+        patterns:
+          - "*"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @advanced-security/advanced-security-dependency-graph
-* @advanced-security/oss-maintainers
+* @advanced-security/advanced-security-dependency-graph @advanced-security/oss-maintainers


### PR DESCRIPTION
I'm still being pinged to review dependabot PRs for this repo, presumably because there's a syntax error in the CODEOWNERS.

Also fixes the dependabot config to use grouped updates properly (there was a syntax error, and npm updates weren't included).