### PR TITLE
Remove CodeQL config since we use Default Setup

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,0 @@
-name: "javascript-action CodeQL config"
-
-paths-ignore: 
-  - node_modules
-  - dist


### PR DESCRIPTION
Our CodeQL check is failing as we're trying to use both default setup and this configuration file.

We should probably just err on the side of default setup as we're not doing anything out of the ordinary with this config and it is enabled by policy.