### PR TITLE
Potential fix for alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,6 +4,8 @@
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: "Test"
+permissions:
+  contents: read
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/component-detection-dependency-submission-action/security/code-scanning/12](https://github.com/advanced-security/component-detection-dependency-submission-action/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the workflow to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow does not have unnecessary write permissions, reducing the risk of unintended modifications to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
