### PR TITLE
Automate tracked releases and floating version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,156 @@
+name: Release
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".release.yml"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Open a version bump PR. Ignored if version is set."
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+        default: none
+      version:
+        description: "Explicit version to release immediately (e.g., 0.1.5)."
+        type: string
+        default: ""
+      prerelease:
+        description: "Publish the explicit version as a pre-release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.version == '' && inputs.bump != 'none' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Bump version
+        uses: docker://ghcr.io/42bytelabs/patch-release-me:0.6.7@sha256:b9624359ce08707dfb4d22bcbf9d1a75f7f4718ccec610ddaa62280ffea98958
+        with:
+          args: --disable-banner bump -m ${{ inputs.bump }}
+
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24.x
+
+      - name: Sync package lock
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild distribution
+        run: npm run prepare
+
+      - name: Create release pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: bump version (${{ inputs.bump }})"
+          title: "chore: bump version (${{ inputs.bump }})"
+          branch: chore/release-${{ inputs.bump }}
+          base: main
+          body: |
+            Automated pull request to bump the tracked release version,
+            update README.md, synchronize package-lock.json, and rebuild dist/.
+
+  manual-release:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      version: ${{ inputs.version }}
+      prerelease: ${{ inputs.prerelease }}
+
+  fetch-release:
+    if: ${{ github.event_name == 'push' && !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release: ${{ steps.check.outputs.release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check tracked version
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          current_version=$(sed -n -E 's/^version:[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' .release.yml)
+          if [ -z "$current_version" ]; then
+            echo "::error::Could not read a version from .release.yml"
+            exit 1
+          fi
+
+          if ! git cat-file -e "${BEFORE_SHA}:.release.yml" 2>/dev/null; then
+            echo "::notice::Initialized release tracking at v$current_version without publishing a release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          previous_version=$(git show "${BEFORE_SHA}:.release.yml" |
+            sed -n -E 's/^version:[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p')
+          if [ -z "$previous_version" ]; then
+            echo "::error::Could not read the previous version from .release.yml"
+            exit 1
+          fi
+
+          if [ "$current_version" = "$previous_version" ]; then
+            echo "::notice::.release.yml changed without a version bump; no release will be published."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          released_version=""
+          if latest_tag=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/tmp/gh-api-error); then
+            released_version="${latest_tag#v}"
+          elif ! grep -q "HTTP 404" /tmp/gh-api-error; then
+            echo "::error::Failed to look up the latest release"
+            cat /tmp/gh-api-error
+            exit 1
+          fi
+
+          if [ "$current_version" = "$released_version" ]; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$current_version" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: fetch-release
+    if: ${{ needs.fetch-release.outputs.release == 'true' }}
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      version: ${{ needs.fetch-release.outputs.version }}

--- a/.release.yml
+++ b/.release.yml
@@ -1,0 +1,23 @@
+name: "component-detection-dependency-submission-action"
+repository: "advanced-security/component-detection-dependency-submission-action"
+version: "0.1.4"
+default: false
+
+locations:
+  - name: "Node Manifest"
+    paths:
+      - package.json
+    patterns:
+      - '"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'
+
+  - name: "Basic Usage Documentation"
+    paths:
+      - README.md
+    patterns:
+      - 'advanced-security/component-detection-dependency-submission-action@v([0-9]+\.[0-9]+\.[0-9]+)\r?\n```'
+
+  - name: "Configured Usage Documentation"
+    paths:
+      - README.md
+    patterns:
+      - 'advanced-security/component-detection-dependency-submission-action@v([0-9]+\.[0-9]+\.[0-9]+)\r?\n        with:'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
+## Cutting a release
+
+Maintainers can run the [Release workflow](https://github.com/advanced-security/component-detection-dependency-submission-action/actions/workflows/release.yml) with a patch, minor, or major bump. The workflow opens a pull request that updates the tracked version in `.release.yml`, the package manifest and lockfile, the README examples, and `dist/`.
+
+Merging that pull request publishes the matching GitHub release and updates the floating major and minor tags. An explicit version can also be dispatched for an immediate release or pre-release.
+
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.4
 ```
 
 Additional `Experimental` and `DefaultOff`  detectors:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Component detection
-        uses: advanced-security/component-detection-dependency-submission-action@v0.1.1
+        uses: advanced-security/component-detection-dependency-submission-action@v0.1.4
         with:
           # Experimental detectors: Poetry, UvLock, NpmLockfile3, Ivy
           # Default-off detectors: ConanLock, CondaLock, Dockerfile, Pip, SimplePip, Spdx22, Swift

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "component-detection-action",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "component-detection-action",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-detection-action",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "description": "Component detection action",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- add `.release.yml` as the source of truth for repository, package, and README versions
- add a reusable-workflow-backed release pipeline that opens version bump PRs, synchronizes `package-lock.json`, rebuilds `dist/`, and publishes releases after merge
- initialize package metadata and README examples at the existing `v0.1.4` release
- document the automated maintainer release process
- create/update floating major and minor tags only when publishing stable releases

## Release plan

Merging this PR initializes tracking at the existing `v0.1.4` release without republishing it. After merge, dispatch **Release** with `bump: patch`; the workflow will open the `v0.1.5` release PR and update all tracked version references.