### PR TITLE
Require dist validation before publishing releases

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,6 +17,7 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   check-dist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,14 @@ jobs:
             Automated pull request to bump the tracked release version,
             update README.md, synchronize package-lock.json, and rebuild dist/.
 
+  check-dist:
+    if: ${{ (github.event_name == 'push' && !github.event.repository.fork) || (github.event_name == 'workflow_dispatch' && inputs.version != '') }}
+    uses: ./.github/workflows/check-dist.yml
+    permissions:
+      contents: read
+
   manual-release:
+    needs: check-dist
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
     uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
     permissions:
@@ -146,7 +153,7 @@ jobs:
           fi
 
   release:
-    needs: fetch-release
+    needs: [fetch-release, check-dist]
     if: ${{ needs.fetch-release.outputs.release == 'true' }}
     uses: advanced-security/reusable-workflows/.github/workflows/release.yml@cdb58ebdac3e974822957b34c90394db7dd44ccc # v0.3.5
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 Maintainers can run the [Release workflow](https://github.com/advanced-security/component-detection-dependency-submission-action/actions/workflows/release.yml) with a patch, minor, or major bump. The workflow opens a pull request that updates the tracked version in `.release.yml`, the package manifest and lockfile, the README examples, and `dist/`.
 
-Merging that pull request publishes the matching GitHub release and updates the floating major and minor tags. An explicit version can also be dispatched for an immediate release or pre-release.
+Merging that pull request publishes the matching GitHub release and updates the floating major and minor tags. Publication only proceeds after the reusable `check-dist` workflow confirms that the checked-in distribution matches the source. An explicit version can also be dispatched for an immediate release or pre-release.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- make the existing `check-dist` workflow callable as a reusable workflow
- run it as a prerequisite for both tracked-version and explicit-version releases
- prevent publication when rebuilding `dist/` produces a diff or otherwise fails
- document the release prerequisite

Bump-only dispatches still open release PRs without running the prerequisite; the check runs when a release would actually be published.